### PR TITLE
Fix dotnet cloud run function with v3 tracer

### DIFF
--- a/cloud-run-functions/dotnet/Function.cs
+++ b/cloud-run-functions/dotnet/Function.cs
@@ -40,10 +40,8 @@ public class Function : IHttpFunction
 
     public async Task HandleAsync(HttpContext context)
     {
-        using (var scope = Tracer.Instance.StartActive("hello-world-function"))
-        {
-            Log.Information("Hello World!");
-            await context.Response.WriteAsync("Hello World!");
-        }
+        using var scope = Tracer.Instance.StartActive("hello-world-function");
+        Log.Information("Hello World!");
+        await context.Response.WriteAsync("Hello World!");
     }
 }

--- a/cloud-run-functions/dotnet/dotnet.csproj
+++ b/cloud-run-functions/dotnet/dotnet.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.1" />
-    <PackageReference Include="Datadog.Trace.Bundle" Version="3.26.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="3.26.3" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/cloud-run-functions/dotnet/env.yaml
+++ b/cloud-run-functions/dotnet/env.yaml
@@ -1,5 +1,5 @@
 DD_SERVICE: $DD_SERVICE
 CORECLR_ENABLE_PROFILING: "1"
 CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-CORECLR_PROFILER_PATH: "/workspace/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
-DD_DOTNET_TRACER_HOME: "/workspace/datadog"
+CORECLR_PROFILER_PATH: "/layers/google.dotnet.publish/publish/bin/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
+DD_DOTNET_TRACER_HOME: "/layers/google.dotnet.publish/publish/bin/datadog"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Feature / Major Change / Refactor / Optimization
- [x] Bug Fix
- [ ] Documentation Update

## Description

The .NET tracer path has changed in v3 for Google Cloud Run Functions v2

## Related tickets & Documents

## How to reproduce and testing
