### PR TITLE
[SVLS-9037] use update-env-vars for cloud run jobs deploy

### DIFF
--- a/cloud-run-jobs/build_and_deploy.sh
+++ b/cloud-run-jobs/build_and_deploy.sh
@@ -53,7 +53,7 @@ gcloud run jobs deploy $GCP_JOB_NAME \
   --region=$REGION \
   --memory=1024Mi \
   --cpu=1 \
-  --set-env-vars=DD_API_KEY=$DD_API_KEY \
+  --update-env-vars=DD_API_KEY=$DD_API_KEY \
   --labels=service=$DD_SERVICE \
   --project=$PROJECT_ID
 


### PR DESCRIPTION
Addresses review feedback from @apiarian-datadog on https://github.com/DataDog/documentation/pull/37005#issuecomment-4548776234.

## Summary
`cloud-run-jobs/build_and_deploy.sh` was using `--set-env-vars=DD_API_KEY=$DD_API_KEY` on `gcloud run jobs deploy`. `--set-env-vars` is destructive on re-deploy — it replaces the entire env var set on the job, wiping any vars that were added previously (e.g. via `datadog-ci` instrumentation or manual configuration). Switching to `--update-env-vars` mirrors the docs fix and is the safer non-destructive equivalent: it only adds/updates the listed keys and leaves other vars in place.

## Other samples
- `cloud-run/sidecar/` — uses `datadog-ci cloud-run instrument`, no parallel change needed.
- `cloud-run/in-container/` — `DD_LOGS_INJECTION` is set in the app Dockerfiles, not via `--set-env-vars`, so no parallel change needed for the docs issue.

## Test plan
- [ ] No functional changes beyond the flag swap; existing deploy flow remains identical for fresh jobs.
