### PR TITLE
chore: add script for sending traffic to latest revision

### DIFF
--- a/deploy-all-apps.sh
+++ b/deploy-all-apps.sh
@@ -12,6 +12,11 @@
 set -e
 cd "$(dirname "$0")"
 
+if [ -z "$DD_API_KEY" ]; then
+  echo "error: DD_API_KEY is not set" >&2
+  exit 1
+fi
+
 export PROJECT_ID="datadog-serverless-gcp-demo"
 export REGION="us-central1"
 export REPO_NAME="gcp-sample-apps"

--- a/unpin-traffic.sh
+++ b/unpin-traffic.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache 2.0 License.
+
+# This product includes software developed at
+# Datadog (https://www.datadoghq.com/)
+# Copyright 2026-present Datadog, Inc.
+
+# Sends 100% of traffic to the latest revision for every Cloud Run service and
+# function in this repo. Run this after rollback-to-previous.sh has pinned
+# traffic to specific revisions and you want to restore normal behavior.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+PROJECT_ID="datadog-serverless-gcp-demo"
+REGION="us-central1"
+
+PRODUCTS=("cloud-run/in-container/" "cloud-run/sidecar/" "cloud-run-functions/" "cloud-run-jobs/")
+LANGUAGES=("python" "node" "go" "java" "dotnet" "ruby" "php")
+
+# Color codes
+GREEN="\033[0;32m"
+YELLOW_BOLD="\033[1;33m"
+RED="\033[0;31m"
+RESET="\033[0m"
+
+SUMMARY_ROWS=()
+ANY_FAILURE=0
+
+for product in "${PRODUCTS[@]}"; do
+  for language in "${LANGUAGES[@]}"; do
+    if [[ ! -d "${product}${language}" ]]; then
+      continue
+    fi
+
+    # Jobs don't have traffic routing — skip them.
+    if [[ "$product" == "cloud-run-jobs/" ]]; then
+      continue
+    fi
+
+    service_name=$(echo "gcp-sample-apps-${product%/}-${language}" | tr '/' '-')
+
+    echo -e "${YELLOW_BOLD}📌 Unpinning $service_name${RESET}"
+
+    if gcloud run services update-traffic "$service_name" \
+        --to-latest \
+        --region="$REGION" \
+        --project="$PROJECT_ID" \
+        --quiet 2>&1; then
+      echo -e "  ${GREEN}✅ now serving latest revision${RESET}"
+      SUMMARY_ROWS+=("OK	$service_name")
+    else
+      echo -e "  ${RED}❌ failed${RESET}"
+      SUMMARY_ROWS+=("FAIL	$service_name")
+      ANY_FAILURE=1
+    fi
+  done
+done
+
+echo ""
+echo -e "${YELLOW_BOLD}=== Summary ===${RESET}"
+for row in "${SUMMARY_ROWS[@]}"; do
+  IFS=$'\t' read -r status name <<< "$row"
+  printf '%-6s  %s\n' "$status" "$name"
+done
+
+echo ""
+if [[ "$ANY_FAILURE" == "1" ]]; then
+  echo -e "${RED}One or more services failed to unpin.${RESET}" >&2
+  exit 1
+fi
+echo -e "${GREEN}All services unpinned to latest.${RESET}"


### PR DESCRIPTION
## Description
- Adds `unpin-traffic.sh`: routes 100% of traffic to the latest revision for every Cloud Run service and function in the repo. Run this when traffic has been pinned to a specific revision and you want to restore normal behavior as redeploying did not automatically send traffic to the latest revision.
- Adds a `DD_API_KEY` presence check at the top of `deploy-all-apps.sh` that fails fast with a clear error rather than silently deploying services with an empty API key.

## Context

Both `rollback-to-previous.sh` and `restore-current.sh` use `--to-revisions=X=100` to pin traffic to specific revision names. Once pinned, subsequent `deploy-all-apps.sh` runs create new revisions but don't move traffic to them — changes appear deployed but have no effect. `unpin-traffic.sh` breaks that pin and should be run after `restore-current.sh` to return to normal latest-revision routing.

## Related tickets & Documents

https://datadoghq.atlassian.net/browse/SVLS-9116
