### PR TITLE
chore(deps): consolidate bot dependency updates

### DIFF
--- a/cloud-run-functions/go/go.mod
+++ b/cloud-run-functions/go/go.mod
@@ -79,7 +79,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/mod v0.33.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260209200024-4cfbd4190f57 // indirect

--- a/cloud-run-functions/go/go.sum
+++ b/cloud-run-functions/go/go.sum
@@ -271,8 +271,8 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/cloud-run-functions/java/pom.xml
+++ b/cloud-run-functions/java/pom.xml
@@ -32,12 +32,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.21.4</version>
+            <version>2.22.0</version>
         </dependency>
         <dependency>
             <groupId>com.datadoghq</groupId>
             <artifactId>dd-trace-api</artifactId>
-            <version>1.62.0</version>
+            <version>1.63.2</version>
         </dependency>
     </dependencies>
     

--- a/cloud-run-functions/java/pom.xml
+++ b/cloud-run-functions/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.21.4</version>
+            <version>2.22.0</version>
         </dependency>
         <dependency>
             <groupId>com.datadoghq</groupId>

--- a/cloud-run-functions/node/package-lock.json
+++ b/cloud-run-functions/node/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@google-cloud/functions-framework": "^5.0.2",
-        "dd-trace": "^5.105.0",
+        "dd-trace": "^5.110.0",
         "winston": "^3.19.0"
       }
     },
@@ -64,9 +64,9 @@
       }
     },
     "node_modules/@datadog/libdatadog": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.9.3.tgz",
-      "integrity": "sha512-L+scIlcRRRF0qjeSU3VQLQlqezfQHkDdnOdbmx/gLjPqewKSyqVGp7XRdKXYo2vZTzmG8dH6rPKXwgI68UQufw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.9.4.tgz",
+      "integrity": "sha512-55wHHAuhHOOrBGoWV+fRuEDypN6PMJZq4LTOwExnhoDMvVcZKtqYT05xea/toRs0o75+A1IeNAQHsRLbJMf5oA==",
       "license": "Apache-2.0",
       "optional": true
     },
@@ -111,13 +111,13 @@
       }
     },
     "node_modules/@datadog/openfeature-node-server": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-1.2.1.tgz",
-      "integrity": "sha512-iY32juuL2w07vOlrTG1Y1U0y3ehyvRxuwzJvaLqjmQE8jj2L3o2SRm2UwgmLnzh6JWzMfNxbfs66KvOmPja7dQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-2.0.0.tgz",
+      "integrity": "sha512-Ummu/Bd7ZJpCCNdFnZUt/JI+L1+8OMK53+MyIXbS7dCt4JXWWwelbpzSGqmC2jWbWQ/mTo4hEfnFw3kYOINbXA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@datadog/flagging-core": "^1.2.1"
+        "@datadog/flagging-core": "1.2.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@datadog/pprof": {
-      "version": "5.14.4",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.14.4.tgz",
-      "integrity": "sha512-egEZDD9v98RBI8ijbHyaWQeY8rW0WEu004As5D7SUkdqSMORhrnh7ZdsM46PUzQgAc85IaEZoukWS9UhMvWn9w==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.15.1.tgz",
+      "integrity": "sha512-4mI750tX6okNROS4YKvGQjyAQ+VqfzDqzysCytOJhL2E2ktK/q4M0PtC7j70tiirGb/fO9fjma3IMNSRLYX+xQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -264,17 +264,17 @@
       }
     },
     "node_modules/@openfeature/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-C3ynxtPYhe5qVJgQIqCNxZXeRXo4t1Eo86uiROr8+sD6F2OjEJGIp6VOGxz+r6jkad2s8Br9BnUJOvskhai/3A==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-P0u3/ht/oZCQT89fOed+laLk0kZR529a825cS02uPDglxXbE97irWYpDAeRGGVETIzKfuy+H2g8c3Ccv/tXJNQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true
     },
     "node_modules/@openfeature/server-sdk": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.21.0.tgz",
-      "integrity": "sha512-ZBVAiyMeN+dxurcXGJlvuOpYg9X7V923MVCI5dq/kE/5o8ys7MCOPhW44e4PS+XABHzSRTw44hcgWez93xwifw==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.22.0.tgz",
+      "integrity": "sha512-YBrf6SQkn0FNB/dRAtLEs41dvFMUE8CrQTwI+iLaMFUIqWlqGNJfGnulKSneEKS+2OgKTAC6DdmKcZ6tK7kBcg==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -282,7 +282,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@openfeature/core": "^1.10.0"
+        "@openfeature/core": "^1.11.0"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -774,9 +774,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -1063,26 +1063,25 @@
       }
     },
     "node_modules/dd-trace": {
-      "version": "5.105.0",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.105.0.tgz",
-      "integrity": "sha512-nu0GNq09iwf4X+nOz+32fo6f7oajj7hFAMewW2JO5L423gp2csIye4CJs0mqGxNI/1sltaKmyVAuuUhOMrJbLw==",
-      "hasInstallScript": true,
+      "version": "5.110.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.110.0.tgz",
+      "integrity": "sha512-/PeVFa9lSbaJ2b1M233nX0LF+5RMRwdjv22uotNbdtWz7lQk1om8U8ngm07Cf/hrzVMMPvA3Cufy3iZgZOTNkA==",
       "license": "(Apache-2.0 OR BSD-3-Clause)",
       "dependencies": {
         "dc-polyfill": "^0.1.11",
-        "import-in-the-middle": "^3.0.1",
+        "import-in-the-middle": "^3.1.0",
         "opentracing": ">=0.14.7"
       },
       "engines": {
-        "node": ">=18 <27"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@datadog/libdatadog": "0.9.3",
+        "@datadog/libdatadog": "0.9.4",
         "@datadog/native-appsec": "11.0.1",
         "@datadog/native-iast-taint-tracking": "4.2.0",
         "@datadog/native-metrics": "3.1.2",
-        "@datadog/openfeature-node-server": "1.2.1",
-        "@datadog/pprof": "5.14.4",
+        "@datadog/openfeature-node-server": "2.0.0",
+        "@datadog/pprof": "5.15.1",
         "@datadog/wasm-js-rewriter": "5.0.1",
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "@opentelemetry/api-logs": "<1.0.0",
@@ -1522,9 +1521,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
-      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.2.0.tgz",
+      "integrity": "sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -1973,9 +1972,9 @@
       }
     },
     "node_modules/pprof-format": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.1.tgz",
-      "integrity": "sha512-p4tVN7iK19ccDqQv8heyobzUmbHyds4N2FI6aBMcXz6y99MglTWDxIyhFkNaLeEXs6IFUEzT0zya0icbSLLY0g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.2.tgz",
+      "integrity": "sha512-hd90rHVDhNOhgHTmazVzDSVwTLOBjpZQ26AO/0j46sAFZ9uSWY0DcK2zJcwnuo2R6EzufBbOoWlPazA5nSyHcg==",
       "license": "MIT",
       "optional": true
     },

--- a/cloud-run-functions/node/package-lock.json
+++ b/cloud-run-functions/node/package-lock.json
@@ -795,9 +795,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1262,9 +1262,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",
@@ -1668,9 +1668,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1957,6 +1967,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2002,12 +2022,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -2113,16 +2134,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/safe-buffer": {
@@ -2250,14 +2261,14 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2269,13 +2280,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/cloud-run-functions/node/package.json
+++ b/cloud-run-functions/node/package.json
@@ -2,7 +2,7 @@
   "main": "index.js",
   "dependencies": {
     "@google-cloud/functions-framework": "^5.0.2",
-    "dd-trace": "^5.105.0",
+    "dd-trace": "^5.110.0",
     "winston": "^3.19.0"
   }
 }

--- a/cloud-run-functions/python/requirements.txt
+++ b/cloud-run-functions/python/requirements.txt
@@ -1,2 +1,2 @@
-datadog==0.52.1
-ddtrace==4.10.0
+datadog==0.52.2
+ddtrace==4.10.5

--- a/cloud-run-functions/ruby/Gemfile.lock
+++ b/cloud-run-functions/ruby/Gemfile.lock
@@ -2,12 +2,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.3.0)
-    cgi (0.5.1)
+    cgi (0.5.2)
     cloud_events (0.7.1)
-    datadog (2.34.0)
+    datadog (2.36.0)
       cgi
       datadog-ruby_core_source (~> 3.5, >= 3.5.2)
-      libdatadog (~> 33.0.0.1.0)
+      libdatadog (~> 35.0.0.1.0)
       libddwaf (~> 1.30.0.0.0)
       logger
       msgpack
@@ -18,14 +18,14 @@ GEM
       cloud_events (>= 0.7.0, < 2.a)
       puma (>= 4.3.0, < 7.a)
       rack (>= 2.1, < 4.a)
-    libdatadog (33.0.0.1.0-arm64-darwin)
-    libdatadog (33.0.0.1.0-x86_64-linux)
+    libdatadog (35.0.0.1.0-arm64-darwin)
+    libdatadog (35.0.0.1.0-x86_64-linux)
     libddwaf (1.30.0.0.2-arm64-darwin)
       ffi (~> 1.0)
     libddwaf (1.30.0.0.2-x86_64-linux)
       ffi (~> 1.0)
     logger (1.7.0)
-    msgpack (1.8.1)
+    msgpack (1.8.3)
     nio4r (2.7.4)
     puma (6.6.1)
       nio4r (~> 2.0)

--- a/cloud-run-jobs/dotnet/Dockerfile
+++ b/cloud-run-jobs/dotnet/Dockerfile
@@ -5,7 +5,7 @@
 # Datadog (https://www.datadoghq.com/)
 # Copyright 2025-present Datadog, Inc.
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0.300 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.301 AS build
 WORKDIR /app
 
 COPY *.csproj ./
@@ -14,7 +14,7 @@ RUN dotnet restore dotnet.csproj
 COPY . .
 RUN dotnet publish dotnet.csproj -c Release -o out --no-restore
 
-FROM mcr.microsoft.com/dotnet/runtime:10.0.8
+FROM mcr.microsoft.com/dotnet/runtime:10.0.9
 WORKDIR /app
 
 # Copy the built application

--- a/cloud-run-jobs/dotnet/dotnet.csproj
+++ b/cloud-run-jobs/dotnet/dotnet.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace.Bundle" Version="3.44.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="3.47.0" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>

--- a/cloud-run-jobs/go/Dockerfile
+++ b/cloud-run-jobs/go/Dockerfile
@@ -5,7 +5,7 @@
 # Datadog (https://www.datadoghq.com/)
 # Copyright 2025-present Datadog, Inc.
 
-FROM golang:1.26.3-bookworm
+FROM golang:1.26.4-bookworm
 
 WORKDIR /app
 

--- a/cloud-run-jobs/go/go.mod
+++ b/cloud-run-jobs/go/go.mod
@@ -74,7 +74,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/mod v0.33.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260209200024-4cfbd4190f57 // indirect

--- a/cloud-run-jobs/go/go.sum
+++ b/cloud-run-jobs/go/go.sum
@@ -265,8 +265,8 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/cloud-run-jobs/java/pom.xml
+++ b/cloud-run-jobs/java/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>com.datadoghq</groupId>
 			<artifactId>dd-trace-api</artifactId>
-			<version>1.62.0</version>
+			<version>1.63.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.21.4</version>
+			<version>2.22.0</version>
 		</dependency>
 	</dependencies>
 

--- a/cloud-run-jobs/java/pom.xml
+++ b/cloud-run-jobs/java/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.21.4</version>
+			<version>2.22.0</version>
 		</dependency>
 	</dependencies>
 

--- a/cloud-run-jobs/node/package-lock.json
+++ b/cloud-run-jobs/node/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "dd-trace": "^5.105.0",
+        "dd-trace": "^5.110.0",
         "winston": "^3.19.0"
       }
     },
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@datadog/libdatadog": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.9.3.tgz",
-      "integrity": "sha512-L+scIlcRRRF0qjeSU3VQLQlqezfQHkDdnOdbmx/gLjPqewKSyqVGp7XRdKXYo2vZTzmG8dH6rPKXwgI68UQufw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.9.4.tgz",
+      "integrity": "sha512-55wHHAuhHOOrBGoWV+fRuEDypN6PMJZq4LTOwExnhoDMvVcZKtqYT05xea/toRs0o75+A1IeNAQHsRLbJMf5oA==",
       "license": "Apache-2.0",
       "optional": true
     },
@@ -87,13 +87,13 @@
       }
     },
     "node_modules/@datadog/openfeature-node-server": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-1.2.1.tgz",
-      "integrity": "sha512-iY32juuL2w07vOlrTG1Y1U0y3ehyvRxuwzJvaLqjmQE8jj2L3o2SRm2UwgmLnzh6JWzMfNxbfs66KvOmPja7dQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-2.0.0.tgz",
+      "integrity": "sha512-Ummu/Bd7ZJpCCNdFnZUt/JI+L1+8OMK53+MyIXbS7dCt4JXWWwelbpzSGqmC2jWbWQ/mTo4hEfnFw3kYOINbXA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@datadog/flagging-core": "^1.2.1"
+        "@datadog/flagging-core": "1.2.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -103,9 +103,9 @@
       }
     },
     "node_modules/@datadog/pprof": {
-      "version": "5.14.4",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.14.4.tgz",
-      "integrity": "sha512-egEZDD9v98RBI8ijbHyaWQeY8rW0WEu004As5D7SUkdqSMORhrnh7ZdsM46PUzQgAc85IaEZoukWS9UhMvWn9w==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.15.1.tgz",
+      "integrity": "sha512-4mI750tX6okNROS4YKvGQjyAQ+VqfzDqzysCytOJhL2E2ktK/q4M0PtC7j70tiirGb/fO9fjma3IMNSRLYX+xQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -208,17 +208,17 @@
       }
     },
     "node_modules/@openfeature/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-C3ynxtPYhe5qVJgQIqCNxZXeRXo4t1Eo86uiROr8+sD6F2OjEJGIp6VOGxz+r6jkad2s8Br9BnUJOvskhai/3A==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-P0u3/ht/oZCQT89fOed+laLk0kZR529a825cS02uPDglxXbE97irWYpDAeRGGVETIzKfuy+H2g8c3Ccv/tXJNQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true
     },
     "node_modules/@openfeature/server-sdk": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.21.0.tgz",
-      "integrity": "sha512-ZBVAiyMeN+dxurcXGJlvuOpYg9X7V923MVCI5dq/kE/5o8ys7MCOPhW44e4PS+XABHzSRTw44hcgWez93xwifw==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.22.0.tgz",
+      "integrity": "sha512-YBrf6SQkn0FNB/dRAtLEs41dvFMUE8CrQTwI+iLaMFUIqWlqGNJfGnulKSneEKS+2OgKTAC6DdmKcZ6tK7kBcg==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -226,7 +226,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@openfeature/core": "^1.10.0"
+        "@openfeature/core": "^1.11.0"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -611,9 +611,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -706,26 +706,25 @@
       }
     },
     "node_modules/dd-trace": {
-      "version": "5.105.0",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.105.0.tgz",
-      "integrity": "sha512-nu0GNq09iwf4X+nOz+32fo6f7oajj7hFAMewW2JO5L423gp2csIye4CJs0mqGxNI/1sltaKmyVAuuUhOMrJbLw==",
-      "hasInstallScript": true,
+      "version": "5.110.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.110.0.tgz",
+      "integrity": "sha512-/PeVFa9lSbaJ2b1M233nX0LF+5RMRwdjv22uotNbdtWz7lQk1om8U8ngm07Cf/hrzVMMPvA3Cufy3iZgZOTNkA==",
       "license": "(Apache-2.0 OR BSD-3-Clause)",
       "dependencies": {
         "dc-polyfill": "^0.1.11",
-        "import-in-the-middle": "^3.0.1",
+        "import-in-the-middle": "^3.1.0",
         "opentracing": ">=0.14.7"
       },
       "engines": {
-        "node": ">=18 <27"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@datadog/libdatadog": "0.9.3",
+        "@datadog/libdatadog": "0.9.4",
         "@datadog/native-appsec": "11.0.1",
         "@datadog/native-iast-taint-tracking": "4.2.0",
         "@datadog/native-metrics": "3.1.2",
-        "@datadog/openfeature-node-server": "1.2.1",
-        "@datadog/pprof": "5.14.4",
+        "@datadog/openfeature-node-server": "2.0.0",
+        "@datadog/pprof": "5.15.1",
         "@datadog/wasm-js-rewriter": "5.0.1",
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "@opentelemetry/api-logs": "<1.0.0",
@@ -751,9 +750,9 @@
       "license": "MIT"
     },
     "node_modules/import-in-the-middle": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
-      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.2.0.tgz",
+      "integrity": "sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -917,9 +916,9 @@
       }
     },
     "node_modules/pprof-format": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.1.tgz",
-      "integrity": "sha512-p4tVN7iK19ccDqQv8heyobzUmbHyds4N2FI6aBMcXz6y99MglTWDxIyhFkNaLeEXs6IFUEzT0zya0icbSLLY0g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.2.tgz",
+      "integrity": "sha512-hd90rHVDhNOhgHTmazVzDSVwTLOBjpZQ26AO/0j46sAFZ9uSWY0DcK2zJcwnuo2R6EzufBbOoWlPazA5nSyHcg==",
       "license": "MIT",
       "optional": true
     },

--- a/cloud-run-jobs/node/package-lock.json
+++ b/cloud-run-jobs/node/package-lock.json
@@ -784,9 +784,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/cloud-run-jobs/node/package.json
+++ b/cloud-run-jobs/node/package.json
@@ -1,7 +1,7 @@
 {
   "main": "main.js",
   "dependencies": {
-    "dd-trace": "^5.105.0",
+    "dd-trace": "^5.110.0",
     "winston": "^3.19.0"
   }
 }

--- a/cloud-run-jobs/php/Dockerfile
+++ b/cloud-run-jobs/php/Dockerfile
@@ -5,7 +5,7 @@
 # Datadog (https://www.datadoghq.com/)
 # Copyright 2025-present Datadog, Inc.
 
-FROM php:8.5.6-cli
+FROM php:8.5.7-cli
 
 WORKDIR /app
 

--- a/cloud-run-jobs/python/Dockerfile
+++ b/cloud-run-jobs/python/Dockerfile
@@ -5,7 +5,7 @@
 # Datadog (https://www.datadoghq.com/)
 # Copyright 2025-present Datadog, Inc.
 
-FROM python:3.14.5-slim
+FROM python:3.14.6-slim
 
 WORKDIR /app
 

--- a/cloud-run-jobs/python/requirements.txt
+++ b/cloud-run-jobs/python/requirements.txt
@@ -1,4 +1,4 @@
-datadog==0.52.1
-ddtrace==4.10.0
+datadog==0.52.2
+ddtrace==4.10.5
 gunicorn==26.0.0
-structlog==25.5.0
+structlog==26.1.0

--- a/cloud-run-jobs/ruby/Gemfile.lock
+++ b/cloud-run-jobs/ruby/Gemfile.lock
@@ -1,25 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cgi (0.5.1)
-    datadog (2.34.0)
+    cgi (0.5.2)
+    datadog (2.36.0)
       cgi
       datadog-ruby_core_source (~> 3.5, >= 3.5.2)
-      libdatadog (~> 33.0.0.1.0)
+      libdatadog (~> 35.0.0.1.0)
       libddwaf (~> 1.30.0.0.0)
       logger
       msgpack
     datadog-ruby_core_source (3.5.2)
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
-    libdatadog (33.0.0.1.0-arm64-darwin)
-    libdatadog (33.0.0.1.0-x86_64-linux)
+    libdatadog (35.0.0.1.0-arm64-darwin)
+    libdatadog (35.0.0.1.0-x86_64-linux)
     libddwaf (1.30.0.0.2-arm64-darwin)
       ffi (~> 1.0)
     libddwaf (1.30.0.0.2-x86_64-linux)
       ffi (~> 1.0)
     logger (1.7.0)
-    msgpack (1.8.1)
+    msgpack (1.8.3)
 
 PLATFORMS
   arm64-darwin-23

--- a/cloud-run/in-container/dotnet/Dockerfile
+++ b/cloud-run/in-container/dotnet/Dockerfile
@@ -5,7 +5,7 @@
 # Datadog (https://www.datadoghq.com/)
 # Copyright 2025-present Datadog, Inc.
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0.300 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.301 AS build
 WORKDIR /app
 
 COPY *.csproj ./
@@ -14,7 +14,7 @@ RUN dotnet restore dotnet.csproj
 COPY . .
 RUN dotnet publish dotnet.csproj -c Release -o out --no-restore
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.8
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.9
 WORKDIR /app
 
 # Copy the built application

--- a/cloud-run/in-container/go/Dockerfile
+++ b/cloud-run/in-container/go/Dockerfile
@@ -5,7 +5,7 @@
 # Datadog (https://www.datadoghq.com/)
 # Copyright 2025-present Datadog, Inc.
 
-FROM golang:1.26.3-bookworm
+FROM golang:1.26.4-bookworm
 
 WORKDIR /app
 

--- a/cloud-run/in-container/go/go.mod
+++ b/cloud-run/in-container/go/go.mod
@@ -76,7 +76,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/mod v0.33.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260209200024-4cfbd4190f57 // indirect

--- a/cloud-run/in-container/go/go.sum
+++ b/cloud-run/in-container/go/go.sum
@@ -267,8 +267,8 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/cloud-run/in-container/java/pom.xml
+++ b/cloud-run/in-container/java/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/>
 	</parent>
 	<groupId>com.example</groupId>
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>com.datadoghq</groupId>
 			<artifactId>dd-trace-api</artifactId>
-			<version>1.62.0</version>
+			<version>1.63.2</version>
 		</dependency>
 	</dependencies>
 

--- a/cloud-run/in-container/node/package-lock.json
+++ b/cloud-run/in-container/node/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "dd-trace": "^5.105.0",
+        "dd-trace": "^5.110.0",
         "express": "^5.2.1",
         "winston": "^3.19.0"
       }
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@datadog/libdatadog": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.9.3.tgz",
-      "integrity": "sha512-L+scIlcRRRF0qjeSU3VQLQlqezfQHkDdnOdbmx/gLjPqewKSyqVGp7XRdKXYo2vZTzmG8dH6rPKXwgI68UQufw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.9.4.tgz",
+      "integrity": "sha512-55wHHAuhHOOrBGoWV+fRuEDypN6PMJZq4LTOwExnhoDMvVcZKtqYT05xea/toRs0o75+A1IeNAQHsRLbJMf5oA==",
       "license": "Apache-2.0",
       "optional": true
     },
@@ -88,13 +88,13 @@
       }
     },
     "node_modules/@datadog/openfeature-node-server": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-1.2.1.tgz",
-      "integrity": "sha512-iY32juuL2w07vOlrTG1Y1U0y3ehyvRxuwzJvaLqjmQE8jj2L3o2SRm2UwgmLnzh6JWzMfNxbfs66KvOmPja7dQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-2.0.0.tgz",
+      "integrity": "sha512-Ummu/Bd7ZJpCCNdFnZUt/JI+L1+8OMK53+MyIXbS7dCt4JXWWwelbpzSGqmC2jWbWQ/mTo4hEfnFw3kYOINbXA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@datadog/flagging-core": "^1.2.1"
+        "@datadog/flagging-core": "1.2.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@datadog/pprof": {
-      "version": "5.14.4",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.14.4.tgz",
-      "integrity": "sha512-egEZDD9v98RBI8ijbHyaWQeY8rW0WEu004As5D7SUkdqSMORhrnh7ZdsM46PUzQgAc85IaEZoukWS9UhMvWn9w==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.15.1.tgz",
+      "integrity": "sha512-4mI750tX6okNROS4YKvGQjyAQ+VqfzDqzysCytOJhL2E2ktK/q4M0PtC7j70tiirGb/fO9fjma3IMNSRLYX+xQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -219,17 +219,17 @@
       }
     },
     "node_modules/@openfeature/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-C3ynxtPYhe5qVJgQIqCNxZXeRXo4t1Eo86uiROr8+sD6F2OjEJGIp6VOGxz+r6jkad2s8Br9BnUJOvskhai/3A==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-P0u3/ht/oZCQT89fOed+laLk0kZR529a825cS02uPDglxXbE97irWYpDAeRGGVETIzKfuy+H2g8c3Ccv/tXJNQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true
     },
     "node_modules/@openfeature/server-sdk": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.21.0.tgz",
-      "integrity": "sha512-ZBVAiyMeN+dxurcXGJlvuOpYg9X7V923MVCI5dq/kE/5o8ys7MCOPhW44e4PS+XABHzSRTw44hcgWez93xwifw==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.22.0.tgz",
+      "integrity": "sha512-YBrf6SQkn0FNB/dRAtLEs41dvFMUE8CrQTwI+iLaMFUIqWlqGNJfGnulKSneEKS+2OgKTAC6DdmKcZ6tK7kBcg==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -237,7 +237,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@openfeature/core": "^1.10.0"
+        "@openfeature/core": "^1.11.0"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -635,9 +635,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -831,26 +831,25 @@
       }
     },
     "node_modules/dd-trace": {
-      "version": "5.105.0",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.105.0.tgz",
-      "integrity": "sha512-nu0GNq09iwf4X+nOz+32fo6f7oajj7hFAMewW2JO5L423gp2csIye4CJs0mqGxNI/1sltaKmyVAuuUhOMrJbLw==",
-      "hasInstallScript": true,
+      "version": "5.110.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.110.0.tgz",
+      "integrity": "sha512-/PeVFa9lSbaJ2b1M233nX0LF+5RMRwdjv22uotNbdtWz7lQk1om8U8ngm07Cf/hrzVMMPvA3Cufy3iZgZOTNkA==",
       "license": "(Apache-2.0 OR BSD-3-Clause)",
       "dependencies": {
         "dc-polyfill": "^0.1.11",
-        "import-in-the-middle": "^3.0.1",
+        "import-in-the-middle": "^3.1.0",
         "opentracing": ">=0.14.7"
       },
       "engines": {
-        "node": ">=18 <27"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@datadog/libdatadog": "0.9.3",
+        "@datadog/libdatadog": "0.9.4",
         "@datadog/native-appsec": "11.0.1",
         "@datadog/native-iast-taint-tracking": "4.2.0",
         "@datadog/native-metrics": "3.1.2",
-        "@datadog/openfeature-node-server": "1.2.1",
-        "@datadog/pprof": "5.14.4",
+        "@datadog/openfeature-node-server": "2.0.0",
+        "@datadog/pprof": "5.15.1",
         "@datadog/wasm-js-rewriter": "5.0.1",
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "@opentelemetry/api-logs": "<1.0.0",
@@ -1172,9 +1171,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
-      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.2.0.tgz",
+      "integrity": "sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -1445,9 +1444,9 @@
       }
     },
     "node_modules/pprof-format": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.1.tgz",
-      "integrity": "sha512-p4tVN7iK19ccDqQv8heyobzUmbHyds4N2FI6aBMcXz6y99MglTWDxIyhFkNaLeEXs6IFUEzT0zya0icbSLLY0g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.2.tgz",
+      "integrity": "sha512-hd90rHVDhNOhgHTmazVzDSVwTLOBjpZQ26AO/0j46sAFZ9uSWY0DcK2zJcwnuo2R6EzufBbOoWlPazA5nSyHcg==",
       "license": "MIT",
       "optional": true
     },

--- a/cloud-run/in-container/node/package-lock.json
+++ b/cloud-run/in-container/node/package-lock.json
@@ -937,9 +937,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1124,9 +1124,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1220,9 +1220,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1444,6 +1454,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/pprof-format": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.1.tgz",
@@ -1465,12 +1485,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1531,16 +1552,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/safe-buffer": {
@@ -1622,14 +1633,14 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1641,13 +1652,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/cloud-run/in-container/node/package.json
+++ b/cloud-run/in-container/node/package.json
@@ -1,7 +1,7 @@
 {
   "main": "main.js",
   "dependencies": {
-    "dd-trace": "^5.105.0",
+    "dd-trace": "^5.110.0",
     "express": "^5.2.1",
     "winston": "^3.19.0"
   }

--- a/cloud-run/in-container/php/Dockerfile
+++ b/cloud-run/in-container/php/Dockerfile
@@ -5,7 +5,7 @@
 # Datadog (https://www.datadoghq.com/)
 # Copyright 2025-present Datadog, Inc.
 
-FROM php:8.5.6-apache
+FROM php:8.5.7-apache
 
 WORKDIR /var/www/html
 

--- a/cloud-run/in-container/python/Dockerfile
+++ b/cloud-run/in-container/python/Dockerfile
@@ -5,7 +5,7 @@
 # Datadog (https://www.datadoghq.com/)
 # Copyright 2025-present Datadog, Inc.
 
-FROM python:3.14.5-slim
+FROM python:3.14.6-slim
 
 WORKDIR /app
 

--- a/cloud-run/in-container/python/requirements.txt
+++ b/cloud-run/in-container/python/requirements.txt
@@ -1,5 +1,5 @@
-datadog==0.52.1
-ddtrace==4.10.0
+datadog==0.52.2
+ddtrace==4.10.5
 Flask==3.1.3
 gunicorn==26.0.0
-structlog==25.5.0
+structlog==26.1.0

--- a/cloud-run/in-container/ruby/Gemfile.lock
+++ b/cloud-run/in-container/ruby/Gemfile.lock
@@ -2,25 +2,25 @@ GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.3.0)
-    cgi (0.5.1)
-    datadog (2.34.0)
+    cgi (0.5.2)
+    datadog (2.36.0)
       cgi
       datadog-ruby_core_source (~> 3.5, >= 3.5.2)
-      libdatadog (~> 33.0.0.1.0)
+      libdatadog (~> 35.0.0.1.0)
       libddwaf (~> 1.30.0.0.0)
       logger
       msgpack
     datadog-ruby_core_source (3.5.2)
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
-    libdatadog (33.0.0.1.0-arm64-darwin)
-    libdatadog (33.0.0.1.0-x86_64-linux)
+    libdatadog (35.0.0.1.0-arm64-darwin)
+    libdatadog (35.0.0.1.0-x86_64-linux)
     libddwaf (1.30.0.0.2-arm64-darwin)
       ffi (~> 1.0)
     libddwaf (1.30.0.0.2-x86_64-linux)
       ffi (~> 1.0)
     logger (1.7.0)
-    msgpack (1.8.1)
+    msgpack (1.8.3)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.7.5)

--- a/cloud-run/sidecar/dotnet/Dockerfile
+++ b/cloud-run/sidecar/dotnet/Dockerfile
@@ -5,7 +5,7 @@
 # Datadog (https://www.datadoghq.com/)
 # Copyright 2025-present Datadog, Inc.
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0.300 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.301 AS build
 WORKDIR /app
 
 COPY *.csproj ./
@@ -17,7 +17,7 @@ RUN curl -L -s "https://github.com/DataDog/dd-trace-dotnet/releases/download/v3.
 COPY . .
 RUN dotnet publish dotnet.csproj -c Release -o out --no-restore
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.8
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.9
 WORKDIR /app
 
 # Copy the built application

--- a/cloud-run/sidecar/go/Dockerfile
+++ b/cloud-run/sidecar/go/Dockerfile
@@ -5,7 +5,7 @@
 # Datadog (https://www.datadoghq.com/)
 # Copyright 2025-present Datadog, Inc.
 
-FROM golang:1.26.3-bookworm
+FROM golang:1.26.4-bookworm
 
 WORKDIR /app
 

--- a/cloud-run/sidecar/go/go.mod
+++ b/cloud-run/sidecar/go/go.mod
@@ -76,7 +76,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/mod v0.33.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260209200024-4cfbd4190f57 // indirect

--- a/cloud-run/sidecar/go/go.sum
+++ b/cloud-run/sidecar/go/go.sum
@@ -267,8 +267,8 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/cloud-run/sidecar/java/pom.xml
+++ b/cloud-run/sidecar/java/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/>
 	</parent>
 	<groupId>com.example</groupId>
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>com.datadoghq</groupId>
 			<artifactId>dd-trace-api</artifactId>
-			<version>1.62.0</version>
+			<version>1.63.2</version>
 		</dependency>
 	</dependencies>
 

--- a/cloud-run/sidecar/node/package-lock.json
+++ b/cloud-run/sidecar/node/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "dd-trace": "^5.105.0",
+        "dd-trace": "^5.110.0",
         "express": "^5.2.1",
         "winston": "^3.19.0"
       }
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@datadog/libdatadog": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.9.3.tgz",
-      "integrity": "sha512-L+scIlcRRRF0qjeSU3VQLQlqezfQHkDdnOdbmx/gLjPqewKSyqVGp7XRdKXYo2vZTzmG8dH6rPKXwgI68UQufw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.9.4.tgz",
+      "integrity": "sha512-55wHHAuhHOOrBGoWV+fRuEDypN6PMJZq4LTOwExnhoDMvVcZKtqYT05xea/toRs0o75+A1IeNAQHsRLbJMf5oA==",
       "license": "Apache-2.0",
       "optional": true
     },
@@ -88,13 +88,13 @@
       }
     },
     "node_modules/@datadog/openfeature-node-server": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-1.2.1.tgz",
-      "integrity": "sha512-iY32juuL2w07vOlrTG1Y1U0y3ehyvRxuwzJvaLqjmQE8jj2L3o2SRm2UwgmLnzh6JWzMfNxbfs66KvOmPja7dQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-2.0.0.tgz",
+      "integrity": "sha512-Ummu/Bd7ZJpCCNdFnZUt/JI+L1+8OMK53+MyIXbS7dCt4JXWWwelbpzSGqmC2jWbWQ/mTo4hEfnFw3kYOINbXA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@datadog/flagging-core": "^1.2.1"
+        "@datadog/flagging-core": "1.2.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@datadog/pprof": {
-      "version": "5.14.4",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.14.4.tgz",
-      "integrity": "sha512-egEZDD9v98RBI8ijbHyaWQeY8rW0WEu004As5D7SUkdqSMORhrnh7ZdsM46PUzQgAc85IaEZoukWS9UhMvWn9w==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.15.1.tgz",
+      "integrity": "sha512-4mI750tX6okNROS4YKvGQjyAQ+VqfzDqzysCytOJhL2E2ktK/q4M0PtC7j70tiirGb/fO9fjma3IMNSRLYX+xQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -219,17 +219,17 @@
       }
     },
     "node_modules/@openfeature/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-C3ynxtPYhe5qVJgQIqCNxZXeRXo4t1Eo86uiROr8+sD6F2OjEJGIp6VOGxz+r6jkad2s8Br9BnUJOvskhai/3A==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-P0u3/ht/oZCQT89fOed+laLk0kZR529a825cS02uPDglxXbE97irWYpDAeRGGVETIzKfuy+H2g8c3Ccv/tXJNQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true
     },
     "node_modules/@openfeature/server-sdk": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.21.0.tgz",
-      "integrity": "sha512-ZBVAiyMeN+dxurcXGJlvuOpYg9X7V923MVCI5dq/kE/5o8ys7MCOPhW44e4PS+XABHzSRTw44hcgWez93xwifw==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.22.0.tgz",
+      "integrity": "sha512-YBrf6SQkn0FNB/dRAtLEs41dvFMUE8CrQTwI+iLaMFUIqWlqGNJfGnulKSneEKS+2OgKTAC6DdmKcZ6tK7kBcg==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -237,7 +237,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@openfeature/core": "^1.10.0"
+        "@openfeature/core": "^1.11.0"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -635,9 +635,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -831,26 +831,25 @@
       }
     },
     "node_modules/dd-trace": {
-      "version": "5.105.0",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.105.0.tgz",
-      "integrity": "sha512-nu0GNq09iwf4X+nOz+32fo6f7oajj7hFAMewW2JO5L423gp2csIye4CJs0mqGxNI/1sltaKmyVAuuUhOMrJbLw==",
-      "hasInstallScript": true,
+      "version": "5.110.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.110.0.tgz",
+      "integrity": "sha512-/PeVFa9lSbaJ2b1M233nX0LF+5RMRwdjv22uotNbdtWz7lQk1om8U8ngm07Cf/hrzVMMPvA3Cufy3iZgZOTNkA==",
       "license": "(Apache-2.0 OR BSD-3-Clause)",
       "dependencies": {
         "dc-polyfill": "^0.1.11",
-        "import-in-the-middle": "^3.0.1",
+        "import-in-the-middle": "^3.1.0",
         "opentracing": ">=0.14.7"
       },
       "engines": {
-        "node": ">=18 <27"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@datadog/libdatadog": "0.9.3",
+        "@datadog/libdatadog": "0.9.4",
         "@datadog/native-appsec": "11.0.1",
         "@datadog/native-iast-taint-tracking": "4.2.0",
         "@datadog/native-metrics": "3.1.2",
-        "@datadog/openfeature-node-server": "1.2.1",
-        "@datadog/pprof": "5.14.4",
+        "@datadog/openfeature-node-server": "2.0.0",
+        "@datadog/pprof": "5.15.1",
         "@datadog/wasm-js-rewriter": "5.0.1",
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "@opentelemetry/api-logs": "<1.0.0",
@@ -1172,9 +1171,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
-      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.2.0.tgz",
+      "integrity": "sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -1445,9 +1444,9 @@
       }
     },
     "node_modules/pprof-format": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.1.tgz",
-      "integrity": "sha512-p4tVN7iK19ccDqQv8heyobzUmbHyds4N2FI6aBMcXz6y99MglTWDxIyhFkNaLeEXs6IFUEzT0zya0icbSLLY0g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.2.tgz",
+      "integrity": "sha512-hd90rHVDhNOhgHTmazVzDSVwTLOBjpZQ26AO/0j46sAFZ9uSWY0DcK2zJcwnuo2R6EzufBbOoWlPazA5nSyHcg==",
       "license": "MIT",
       "optional": true
     },

--- a/cloud-run/sidecar/node/package-lock.json
+++ b/cloud-run/sidecar/node/package-lock.json
@@ -937,9 +937,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1124,9 +1124,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1220,9 +1220,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1444,6 +1454,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/pprof-format": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.1.tgz",
@@ -1465,12 +1485,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1531,16 +1552,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/safe-buffer": {
@@ -1622,14 +1633,14 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1641,13 +1652,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/cloud-run/sidecar/node/package.json
+++ b/cloud-run/sidecar/node/package.json
@@ -1,7 +1,7 @@
 {
   "main": "main.js",
   "dependencies": {
-    "dd-trace": "^5.105.0",
+    "dd-trace": "^5.110.0",
     "express": "^5.2.1",
     "winston": "^3.19.0"
   }

--- a/cloud-run/sidecar/php/Dockerfile
+++ b/cloud-run/sidecar/php/Dockerfile
@@ -5,7 +5,7 @@
 # Datadog (https://www.datadoghq.com/)
 # Copyright 2025-present Datadog, Inc.
 
-FROM php:8.5.6-apache
+FROM php:8.5.7-apache
 
 WORKDIR /var/www/html
 

--- a/cloud-run/sidecar/python/Dockerfile
+++ b/cloud-run/sidecar/python/Dockerfile
@@ -5,7 +5,7 @@
 # Datadog (https://www.datadoghq.com/)
 # Copyright 2025-present Datadog, Inc.
 
-FROM python:3.14.5-slim
+FROM python:3.14.6-slim
 
 WORKDIR /app
 

--- a/cloud-run/sidecar/python/requirements.txt
+++ b/cloud-run/sidecar/python/requirements.txt
@@ -1,4 +1,4 @@
-datadog==0.52.1
-ddtrace==4.10.0
+datadog==0.52.2
+ddtrace==4.10.5
 Flask==3.1.3
 gunicorn==26.0.0

--- a/cloud-run/sidecar/ruby/Gemfile.lock
+++ b/cloud-run/sidecar/ruby/Gemfile.lock
@@ -2,25 +2,25 @@ GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.3.0)
-    cgi (0.5.1)
-    datadog (2.34.0)
+    cgi (0.5.2)
+    datadog (2.36.0)
       cgi
       datadog-ruby_core_source (~> 3.5, >= 3.5.2)
-      libdatadog (~> 33.0.0.1.0)
+      libdatadog (~> 35.0.0.1.0)
       libddwaf (~> 1.30.0.0.0)
       logger
       msgpack
     datadog-ruby_core_source (3.5.2)
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
-    libdatadog (33.0.0.1.0-arm64-darwin)
-    libdatadog (33.0.0.1.0-x86_64-linux)
+    libdatadog (35.0.0.1.0-arm64-darwin)
+    libdatadog (35.0.0.1.0-x86_64-linux)
     libddwaf (1.30.0.0.2-arm64-darwin)
       ffi (~> 1.0)
     libddwaf (1.30.0.0.2-x86_64-linux)
       ffi (~> 1.0)
     logger (1.7.0)
-    msgpack (1.8.1)
+    msgpack (1.8.3)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.7.5)


### PR DESCRIPTION
## Combined Automated Dependency Updates

Consolidates 28 open bot dependency PRs (dependabot + campaigner) into one, built by merging each bot branch onto a fresh `main` newest-first.

### Included (28)
- #299 fix(deps): vuln minor upgrades — 5 packages [cloud-run-functions/node]
- #298 fix(deps): vuln minor: js-yaml, path-to-regexp, qs [cloud-run/in-container]
- #297 fix(deps): vuln js-yaml (minor → 4.3.0) [cloud-run-jobs/node]
- #296 fix(deps): vuln minor: js-yaml, path-to-regexp, qs [cloud-run/sidecar]
- #295 chore(deps): golang.org/x/sys (minor → v0.46.0) [cloud-run-functions/go]
- #294 chore(deps): golang.org/x/sys (minor → v0.46.0) [cloud-run-jobs/go]
- #293 chore(deps): golang.org/x/sys (minor → v0.46.0) [cloud-run/in-container]
- #292 chore(deps): golang.org/x/sys (minor → v0.46.0) [cloud-run/sidecar]
- #291 fix(deps): vuln jackson-databind (minor → 2.22.0) [cloud-run-functions/java]
- #290 fix(deps): vuln jackson-databind (minor → 2.22.0) [cloud-run-jobs/java]
- #289 chore(deps): bump the docker-dependencies group across 12 directories
- #288 Bump the dotnet-dependencies group with 1 update
- #287 chore(deps): bump the python-dependencies group in /cloud-run-jobs/python
- #284 chore(deps): bump dd-trace 5.105.0→5.110.0 in /cloud-run-jobs/node
- #283 chore(deps): bump the java-dependencies group in /cloud-run-jobs/java
- #282 chore(deps): bump datadog 2.34.0→2.36.0 in /cloud-run-jobs/ruby
- #276 chore(deps): bump the python-dependencies group in /cloud-run-functions/python
- #275 chore(deps): bump the python-dependencies group in /cloud-run/sidecar/python
- #274 chore(deps): bump the python-dependencies group in /cloud-run/in-container/python
- #273 chore(deps): bump dd-trace 5.105.0→5.110.0 in /cloud-run/in-container/node
- #272 chore(deps): bump dd-trace 5.105.0→5.110.0 in /cloud-run-functions/node
- #271 chore(deps): bump dd-trace 5.105.0→5.110.0 in /cloud-run/sidecar/node
- #270 chore(deps): bump the java-dependencies group in /cloud-run/in-container/java
- #269 chore(deps): bump the java-dependencies group in /cloud-run/sidecar/java
- #268 chore(deps): bump the java-dependencies group in /cloud-run-functions/java
- #267 chore(deps): bump datadog 2.34.0→2.36.0 in /cloud-run-functions/ruby
- #266 chore(deps): bump datadog 2.34.0→2.36.0 in /cloud-run/sidecar/ruby
- #265 chore(deps): bump datadog 2.34.0→2.36.0 in /cloud-run/in-container/ruby

### Skipped — conflicts, left open for the bot to retry (4)
- #285 chore(deps): go-dependencies group in /cloud-run-jobs/go
- #279 chore(deps): go-dependencies group in /cloud-run/sidecar/go
- #278 chore(deps): go-dependencies group in /cloud-run-functions/go
- #277 chore(deps): go-dependencies group in /cloud-run/in-container/go

These conflict with the campaigner `golang.org/x/sys` upgrades (#292–#295) that touch the same go.mod/go.sum and were merged first.
